### PR TITLE
Feat: select 태그 변화 시 환율값 저장 로직 구현

### DIFF
--- a/src/Components/First/index.jsx
+++ b/src/Components/First/index.jsx
@@ -1,21 +1,31 @@
 import { API } from 'API';
-import React, { useEffect, useRef, useState } from 'react';
 import 'Components/First/scss/First.scss';
+import React, { useEffect, useRef, useState } from 'react';
 
 export default function First() {
-  // const [exchange, setExchange] = useState('USDKRW');
   const inputRef = useRef(null);
-
+  const [data, setData] = useState([]);
+  const [select, setSelect] = useState('USDKRW');
+  const [exchange, setExchange] = useState(0);
   useEffect(() => {
     async function getAPI() {
-      await API.Get_API().then((response) => console.log(response.data));
+      await API.Get_API({
+        currencies: 'KRW,JPY,PHP',
+        source: 'USD',
+        format: 1,
+      }).then((response) => setData(response.data.quotes));
     }
     getAPI();
   }, []);
-
-  // const handleExchange = (e) => {
-  //   setExchange(e.currentTarget.value);
-  // };
+  const onChangeSelect = () => {
+    const key = Object.keys(data);
+    const answer = key.find((element) => element.includes(select));
+    setExchange(answer && data[answer].toFixed(2));
+  };
+  useEffect(() => {
+    onChangeSelect();
+  }, [onChangeSelect]);
+  console.log(exchange);
 
   return (
     <section className="First__Container">
@@ -25,7 +35,7 @@ export default function First() {
         <label htmlFor="country">수취국가 : </label>
         <select
           id="country"
-          // onChange={handleExchange}
+          onChange={(event) => setSelect(event.target.value)}
           className="ReceiveCountry">
           <option value="USDKRW">한국(KRW)</option>
           <option value="USDJPY">일본(JPY)</option>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ x ] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- select 태그 변화 시 환율값 저장 로직 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

- <select> 태그 내부의 option이 변하면 onChange Attrubute로 value 저장
- 저장한 value와 API로 받아온 키 값이 일치하는 데이터를 state에 업데이트

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- API Params를 적용해 필요한 데이터만 받아올 수 있도록 하는 법에 대해 숙지할 수 있었습니다.
- Object.key를 활용해 key 값과 <select> 태그 option value를 비교하는 방법에 대해 알게 되었습니다.
- 다만 현재 상태 업데이트를 useEffect로 구현해 렌더링이 여러번 실행되는 점은 기능 구현을 마친 후 리팩토링 과정을 통해 최소화할 예정입니다.

<br />

## :: 기타 질문 및 특이 사항

- 없음
